### PR TITLE
Look Up Git Repo From File And Add Open In GitHub

### DIFF
--- a/content/overlay.xul
+++ b/content/overlay.xul
@@ -32,6 +32,7 @@
 		<command id="Tasks:git_remote_rename" oncommand="extensions.komodo_git.gitRemoteRename();"/>
 		<command id="Tasks:git_remote_set_url" oncommand="extensions.komodo_git.gitRemoteSetUrl();"/>
 		<command id="Tasks:git_add_file" oncommand="extensions.komodo_git.gitAddFile();"/>
+		<command id="Tasks:git_view_on_github" oncommand="extensions.komodo_git.gitViewOnGithub();"/>
 		<command id="Tasks:git_diff_file" oncommand="extensions.komodo_git.gitDiffFile();"/>
 		<command id="Tasks:git_reset_file" oncommand="extensions.komodo_git.gitResetFile();"/>
 		<command id="Tasks:git_add_file_places" oncommand="extensions.komodo_git.gitAddFilePlaces();"/>

--- a/content/pref-overlay.xul
+++ b/content/pref-overlay.xul
@@ -5,7 +5,7 @@
 
 <prefwindow id="komodo_git-prefs"
 	 title="Komodo Git Preferences"
-	 width="210"
+	 width="300"
 	 height="180"
 	 hidechrome="true"
 	 xmlns:html="http://www.w3.org/1999/xhtml"
@@ -40,6 +40,7 @@
 					<menupopup>
 						<menuitem value="currentProject" label="Current project root"/>
 						<menuitem value="placesRoot" label="Places Root"/>
+						<menuitem value="currentFile" label="Current file"/>
 					</menupopup>
 				</menulist>
 			</hbox>

--- a/content/tab-overlay.xul
+++ b/content/tab-overlay.xul
@@ -20,6 +20,10 @@
 					label="Git revert changes in file"
 					observes="Tasks:git_reset_file"
 					class="menu-iconic-wide" />
+			<menuitem id="menu_git_tab_context_menu_file_view_on_github"
+					label="View on GitHub"
+					observes="Tasks:git_view_on_github"
+					class="menu-iconic-wide" />
 			</menupopup>
 		</menu>
 	</menupopup>


### PR DESCRIPTION
- Adding `currentFile` helps when you have a project with multiple git sub-folders.
- Added a link to open a file in GitHub.